### PR TITLE
Feature/bytebuffer speedup

### DIFF
--- a/client/Session.cs
+++ b/client/Session.cs
@@ -694,7 +694,7 @@ namespace iotdb_client_csharp.client
 
         public byte[] value_to_bytes(List<TSDataType> data_types, List<string> values){
 
-            ByteBuffer buffer = new ByteBuffer(new byte[]{});
+            ByteBuffer buffer = new ByteBuffer(values.Count);
             for(int i = 0;i < data_types.Count(); i++){
                 buffer.add_char((char)data_types[i]);
                 switch(data_types[i]){

--- a/client/utils/ByteBuffer.cs
+++ b/client/utils/ByteBuffer.cs
@@ -7,77 +7,99 @@ namespace iotdb_client_csharp.client.utils
     public class ByteBuffer
     {
         private byte[] buffer;
-        private List<byte> write_buffer;
-        private int pos;
+        private int write_pos = 0, read_pos = 0;
         private int total_length;
         private bool is_little_endian;
-        public ByteBuffer(byte[] buffer){            
+        
+        public ByteBuffer(byte[] buffer){   
             this.buffer = buffer;
-            this.pos = 0;
+            this.read_pos = 0;
+            this.write_pos = buffer.Length;
             this.total_length = buffer.Length;
-            this.write_buffer = new List<byte>{};
+            this.is_little_endian = BitConverter.IsLittleEndian;
+        }
+        public ByteBuffer(int reserve = 1){
+            this.buffer = new byte[reserve];
+            this.write_pos = 0;
+            this.read_pos = 0;
+            this.total_length = reserve;
             this.is_little_endian = BitConverter.IsLittleEndian;
         }
         public bool has_remaining(){
-            return pos < total_length;
+            return read_pos < this.write_pos;
         }
         // these for read
         public byte get_byte(){
-            var byte_val = buffer[pos];
-            pos += 1;
+            var byte_val = buffer[read_pos];
+            read_pos += 1;
             return byte_val;
         }
         public bool get_bool(){
-            bool bool_value = BitConverter.ToBoolean(buffer, pos);
-            pos += 1;
+            bool bool_value = BitConverter.ToBoolean(buffer, read_pos);
+            read_pos += 1;
             return bool_value;
         }
         public int get_int(){
 
-            var int_buff = buffer[pos..(pos+4)];
+            var int_buff = buffer[read_pos..(read_pos+4)];
             if(is_little_endian){
                 int_buff = int_buff.Reverse().ToArray();
             }
             int int_value = BitConverter.ToInt32(int_buff);
-            pos += 4;
+            read_pos += 4;
             return int_value;
         }
         public long get_long(){
-            var long_buff = buffer[pos..(pos + 8)];
+            var long_buff = buffer[read_pos..(read_pos + 8)];
             if(is_little_endian){
                 long_buff = long_buff.Reverse().ToArray();
             }
             long long_value = BitConverter.ToInt64(long_buff);
-            pos += 8;
+            read_pos += 8;
             return long_value;
         }
         public float get_float(){
-            var float_buff = buffer[pos..(pos +4)];
+            var float_buff = buffer[read_pos..(read_pos +4)];
             if(is_little_endian){
                 float_buff = float_buff.Reverse().ToArray();
             }
             float float_value = BitConverter.ToSingle(float_buff);
-            pos += 4;
+            read_pos += 4;
             return float_value;
         }
         public double get_double(){
-            var double_buff = buffer[pos..(pos+8)];
+            var double_buff = buffer[read_pos..(read_pos+8)];
             if(is_little_endian){
                 double_buff = double_buff.Reverse().ToArray();
             }
             double double_value = BitConverter.ToDouble(double_buff);
-            pos += 8;
+            read_pos += 8;
             return double_value;
         }
         public string get_str(){
             int length = get_int();
-            var str_buff = buffer[pos..(pos+length)];
+            var str_buff = buffer[read_pos..(read_pos+length)];
             string str_value = System.Text.Encoding.UTF8.GetString(str_buff);
-            pos += length;
+            read_pos += length;
             return str_value;
         }
         public byte[] get_buffer(){
-            return buffer;
+            return buffer[0..this.write_pos];
+        }
+        private int max(int a, int b){
+            if(a <= b){
+                return b;
+            }
+            return a;
+        }
+        private void extend_buffer(int space_need){
+            if(write_pos + space_need >= total_length){
+                total_length = max(space_need, total_length);
+                byte[] new_buffer = new byte[total_length * 2];
+                buffer.CopyTo(new_buffer, 0);
+                buffer = new_buffer;
+                total_length = 2 * total_length;
+            }
         }
         // these for write
         public void add_bool(bool value){
@@ -85,61 +107,67 @@ namespace iotdb_client_csharp.client.utils
             if(is_little_endian){
                 bool_buffer = bool_buffer.Reverse().ToArray();
             }
-            write_buffer.AddRange(BitConverter.GetBytes(value));
-            buffer = write_buffer.ToArray();
-            total_length =  buffer.Length;
+
+            extend_buffer(bool_buffer.Length);
+            bool_buffer.CopyTo(buffer, write_pos);
+            write_pos += bool_buffer.Length;
+
         }
         public void add_int(Int32 value){
             var int_buff = BitConverter.GetBytes(value); 
             if(is_little_endian){
                 int_buff = int_buff.Reverse().ToArray();
             }
-            write_buffer.AddRange(int_buff);
-            buffer = write_buffer.ToArray();
-            total_length =  buffer.Length;
+
+            extend_buffer(int_buff.Length);
+            int_buff.CopyTo(buffer, write_pos);
+            write_pos += int_buff.Length;
         }
         public void add_long(long value){
             var long_buff = BitConverter.GetBytes(value);
             if(is_little_endian){
                 long_buff = long_buff.Reverse().ToArray();
             }
-            write_buffer.AddRange(long_buff);
-            buffer = write_buffer.ToArray();
-            total_length =  buffer.Length;
+            
+            extend_buffer(long_buff.Length);
+            long_buff.CopyTo(buffer, write_pos);
+            write_pos += long_buff.Length;
+
         }
         public void add_float(float value){
             var float_buff = BitConverter.GetBytes(value);
             if(is_little_endian){
                 float_buff = float_buff.Reverse().ToArray();
             }
-            write_buffer.AddRange(float_buff);
-            buffer = write_buffer.ToArray();
-            total_length =  buffer.Length;
+            extend_buffer(float_buff.Length);
+            float_buff.CopyTo(buffer, write_pos);
+            write_pos += float_buff.Length;
         }
         public void add_double(double value){
             var double_buff = BitConverter.GetBytes(value);
             if(is_little_endian){
                 double_buff = double_buff.Reverse().ToArray();
             }
-            write_buffer.AddRange(double_buff);
-            buffer = write_buffer.ToArray();
-            total_length =  buffer.Length;
+            extend_buffer(double_buff.Length);
+            double_buff.CopyTo(buffer, write_pos);
+            write_pos += double_buff.Length;
         }
         public void add_str(string value){
             add_int(value.Length);
             var str_buf = System.Text.Encoding.UTF8.GetBytes(value);
-            write_buffer.AddRange(str_buf);
-            buffer = write_buffer.ToArray();
-            total_length = buffer.Length;
+
+            extend_buffer(str_buf.Length);
+            str_buf.CopyTo(buffer, write_pos);
+            write_pos += str_buf.Length;
         }
         public void add_char(char value){
            var char_buf = BitConverter.GetBytes(value);
            if(is_little_endian){
                char_buf = char_buf.Reverse().ToArray();
            }
-           write_buffer.AddRange(char_buf);
-           buffer = write_buffer.ToArray();
-           total_length =  buffer.Length; 
+           extend_buffer(char_buf.Length);
+           char_buf.CopyTo(buffer, write_pos);
+           write_pos += char_buf.Length;
         }
 
     }

--- a/client/utils/Field.cs
+++ b/client/utils/Field.cs
@@ -6,77 +6,59 @@ namespace iotdb_client_csharp.client.utils
     public class Field
     {
         // TBD By Zengz
-        public bool bool_val;
-        public int int_val;
-        public long long_val;
-        public float float_val;
-        public double double_val;
-        // why we need to keep binary values here 
-        public string str_val;
-
-        private TSDataType type{get;set;}
-        
+        private object val;
+        public TSDataType type{get;set;}
         public Field(TSDataType data_type){
             this.type = data_type;
         }
-
-        public void set(string value){
-            str_val = value;
+        public void set<T>(T value){
+            val = value;
         }
-        public void set(int value){
-            int_val = value;
+        public double get_double(){
+            return type==TSDataType.TEXT?double.Parse((string)val):(double)val;
         }
-        public void set(double value){
-            double_val = value;
+        public Int32 get_int(){
+            return type==TSDataType.TEXT?Int32.Parse((string)val):(Int32)val;
         }
-        public void set(long value){
-            long_val = value;
+        public Int64 get_long(){
+            return type==TSDataType.TEXT?Int64.Parse((string)val):(Int64)val;
         }
-        public void set(float value){
-            float_val = value;
+        public float get_float(){
+            return type==TSDataType.TEXT?float.Parse((string)val):(float)val;
         }
-        public void set(bool value){
-            bool_val = value;
+        public string get_str(){
+            return val.ToString();
         }
         public T get<T>(){
             switch(type){
-                case TSDataType.BOOLEAN:
-                    return (T)(object)bool_val;
-                case TSDataType.INT64:
-                    return (T)(object)long_val;
-                case TSDataType.FLOAT:
-                    return (T)(object)float_val;
-                case TSDataType.INT32:
-                    return (T)(object)int_val;
-                case TSDataType.DOUBLE:
-                    return (T)(object)double_val;
-                case TSDataType.TEXT:
-                    return (T)(object)str_val;
-                default:
+                case TSDataType.NONE :
                     return (T)(object)null;
+                default:
+                    return (T)val;
             }
         }
+        
         public byte[] get_bytes(){
             ByteBuffer buffer = new ByteBuffer(new byte[]{});
             buffer.add_int((int)type);
             switch(type){
                 case TSDataType.BOOLEAN:
-                    buffer.add_bool(bool_val);
+                    buffer.add_bool((bool)val);
                     break;
                 case TSDataType.INT32:
-                    buffer.add_int(int_val);
+                    buffer.add_int((Int32)val);
                     break;
                 case TSDataType.INT64:
-                    buffer.add_long(long_val);
+                    buffer.add_long((Int64)val);
                     break;
                 case TSDataType.FLOAT:
-                    buffer.add_float(float_val);
+                    buffer.add_float((float)val);
                     break;
                 case TSDataType.DOUBLE:
-                    buffer.add_double(double_val);
+                    buffer.add_double((double)val);
                     break;
                 case TSDataType.TEXT:
-                    buffer.add_str(str_val);
+                    buffer.add_str((string)val);
                     break;
                 case TSDataType.NONE:
                     var err_msg = string.Format("NONE type does not support get bytes");
@@ -88,22 +70,10 @@ namespace iotdb_client_csharp.client.utils
         public override string ToString()
         {
             switch(type){
-                case TSDataType.TEXT:
-                    return str_val;
-                case TSDataType.INT32:
-                    return int_val.ToString();
-                case TSDataType.INT64:
-                    return long_val.ToString();
-                case TSDataType.FLOAT:
-                    return float_val.ToString();
-                case TSDataType.DOUBLE:
-                    return double_val.ToString();
-                case TSDataType.BOOLEAN:
-                    return bool_val.ToString();
                 case TSDataType.NONE:
                     return "NULL";
                 default:
-                    return "";
+                    return val.ToString();
             }
         }
 

--- a/client/utils/RowRecord.cs
+++ b/client/utils/RowRecord.cs
@@ -1,21 +1,32 @@
 using System.Collections.Generic;
 using Thrift;
+using System;
 namespace iotdb_client_csharp.client.utils
 {
     public class RowRecord
     {
-        private long timestamp{get;set;}
-        private List<Field> field_lst{get;set;}
+        public long timestamp{get;set;}
+        public List<Field> field_lst{get;set;}
         public RowRecord(long timestamp, List<Field> field_lst){
             this.timestamp = timestamp;
             this.field_lst = field_lst;
         }
-        public void add_filed(Field field){
+        public void add_field(Field field){
+            field_lst.Add(field);
+        }
+        public void append(Field field){
             field_lst.Add(field);
         }
 
         public void set_filed(int index, Field filed){
             field_lst[index] = filed;
+        }
+        public Field this[int index]{
+            get => field_lst[index];
+            set => field_lst[index] = value;
+        }
+        public DateTime TimeStampAsDateTime(){
+            return DateTime.UnixEpoch.AddMilliseconds(timestamp);
         }
         public override string ToString()
         {

--- a/client/utils/Tablet.cs
+++ b/client/utils/Tablet.cs
@@ -69,9 +69,38 @@ namespace iotdb_client_csharp.client.utils
            }
            return buffer.get_buffer();
        }
+       public int estimate_buffer_size(){
+           var estimate_size = 0;
+           // estimate one row size
+           foreach(var data_type in data_type_lst){
+               switch(data_type){
+                    case TSDataType.BOOLEAN:
+                        estimate_size += 1;
+                        break;
+                    case TSDataType.INT32:
+                        estimate_size += 4;
+                        break;
+                    case TSDataType.INT64:
+                        estimate_size += 8;
+                        break;
+                    case TSDataType.FLOAT:
+                        estimate_size += 4;
+                        break;
+                    case TSDataType.DOUBLE:
+                        estimate_size += 8;
+                        break;
+                    case TSDataType.TEXT:
+                        estimate_size += 1;
+                        break;
+               }
+           }
+           estimate_size *= timestamp_lst.Count;
+           return estimate_size;
+       }
        
        public byte[] get_binary_values(){
-           ByteBuffer buffer = new ByteBuffer(new byte[]{});
+           var estimate_size = estimate_buffer_size();
+           ByteBuffer buffer = new ByteBuffer(estimate_size);
            for(int i = 0; i < col_number; i++){
                 switch(data_type_lst[i]){
                     case TSDataType.BOOLEAN:


### PR DESCRIPTION
#16 #15 
## ByteBuffer优化
 - 优化内存使用，使用倍增策略减少内存的申请释放频率，在2万行Tablet的测试下，序列化加速约35倍。
 - ByteBuffer支持同时读取和写入操作，即可以边写入边解析
## Field的改动
 - 在保证原有接口语义的情况下重构代码，使得整个类更美观
 - 支持类型转换
## RowRecord的改动
 - 支持Indexing的操作
 - 支持DateTime的获取，目前暂时默认转换为本地所在TimeZone
